### PR TITLE
fix: Configure Vite for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@
   import path from 'path';
 
   export default defineConfig({
+    base: '/Digital-mental-Health-App/',
     plugins: [react()],
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],


### PR DESCRIPTION
Sets the `base` property in `vite.config.ts` to ensure that assets are loaded correctly when the application is deployed to a subdirectory on GitHub Pages. This resolves the 404 errors and the blank page issue.